### PR TITLE
Retrieve devices on mac osx

### DIFF
--- a/bluecove/src/main/c/intelbth/OSXStack.mm
+++ b/bluecove/src/main/c/intelbth/OSXStack.mm
@@ -650,3 +650,58 @@ JNIEXPORT jstring JNICALL Java_com_intel_bluetooth_BluetoothStackOSX_getLocalDev
              hciVersion.hciVersion, hciVersion.hciRevision);
     return env->NewStringUTF(swVers);
 }
+
+JNIEXPORT jboolean JNICALL Java_com_intel_bluetooth_BluetoothStackOSX_retrieveDevicesImpl
+(JNIEnv *env, jobject peer, jint option, jobject retrieveDevicesCallback) {
+    Edebug(("retrieveDevicesImpl"));
+    RetrieveDevicesCallback callback;
+    if (!callback.builCallback(env, peer, retrieveDevicesCallback)) {
+        return JNI_FALSE;
+    }
+    
+    jboolean result = JNI_TRUE;
+
+    switch (option) {
+        case RETRIEVEDEVICES_OPTION_PREKNOWN: {
+            NSArray* pPairedDevices = [IOBluetoothDevice pairedDevices];
+    
+            if (pPairedDevices != NULL) {
+                int deviceCount = [pPairedDevices count];
+                for (int index = 0; index < deviceCount; index++) {
+                    IOBluetoothDevice* device = (IOBluetoothDevice*)[pPairedDevices objectAtIndex:index];
+                    jlong deviceAddr = OSxAddrToLong( [device getAddress] );
+                    jint deviceClass = (jint) [device classOfDevice];
+                    jstring deviceName = OSxNewJString(env, [device name]);
+                    jboolean paired = JNI_TRUE;
+               
+                    if (!callback.callDeviceFoundCallback(env, deviceAddr, deviceClass, deviceName, paired)) {
+                        result = JNI_FALSE;
+                        break;
+                    }
+                }
+            }
+        }
+        break;
+            
+    default:
+      //Not supported
+      result = JNI_FALSE;
+    }
+    
+    return result;
+}
+
+JNIEXPORT jboolean JNICALL Java_com_intel_bluetooth_BluetoothStackOSX_isRemoteDeviceTrustedImpl
+(JNIEnv *, jobject, jlong) {
+    //TODO: This is just a dummy implementation to prevent UnstatisfiedLinkErrors on OS X
+    return JNI_FALSE;
+}
+
+JNIEXPORT jboolean JNICALL Java_com_intel_bluetooth_BluetoothStackOSX_isRemoteDeviceAuthenticatedImpl
+(JNIEnv *, jobject, jlong) {
+    //TODO: This is just a dummy implementation to prevent UnstatisfiedLinkErrors on OS X
+    return JNI_FALSE;
+}
+
+
+


### PR DESCRIPTION
Implemented the retrieveDevicesImpl function for OS X to allow users to fetch a list of PREKNOWN (paired) devices. The two other methods (isRemoteDeviceTrustedImpl and isRemoteDeviceAuthenticatedImpl) are just dummy implementations to prevent UnstatisfiedLinkErrors at runtime.

PS: I hope this pull request works, I'm new to git.
